### PR TITLE
docs(readme): update release badge to use tags directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # oh-my-gemini-cli (OmG)
-[![Release](https://img.shields.io/github/v/release/Joonghyun-Lee-Frieren/oh-my-gemini-cli?display_name=tag&sort=semver)](https://github.com/Joonghyun-Lee-Frieren/oh-my-gemini-cli/releases)
+[![Release](https://img.shields.io/github/v/tag/Joonghyun-Lee-Frieren/oh-my-gemini-cli?sort=semver&label=release)](https://github.com/Joonghyun-Lee-Frieren/oh-my-gemini-cli/releases)
 [![License](https://img.shields.io/github/license/Joonghyun-Lee-Frieren/oh-my-gemini-cli)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/Joonghyun-Lee-Frieren/oh-my-gemini-cli?style=social)](https://github.com/Joonghyun-Lee-Frieren/oh-my-gemini-cli/stargazers)
 [![Gemini Extension](https://img.shields.io/badge/Gemini-Extension-0d8a83)](https://geminicli.com/extensions/?name=Joonghyun-Lee-Frierenoh-my-gemini-cli)


### PR DESCRIPTION
The release badge was fetching the version from the 'latest' release, which was incorrectly displayed because the 'Set as latest release' option was not checked during the last release. Switching to tag-based versioning ensures the correct version is always shown.

<img width="507" height="203" alt="image" src="https://github.com/user-attachments/assets/99121f71-db65-4b5f-ad0f-a054595528ed" />

---

**before**

[![Release](https://img.shields.io/github/v/release/Joonghyun-Lee-Frieren/oh-my-gemini-cli?display_name=tag&sort=semver)](https://github.com/Joonghyun-Lee-Frieren/oh-my-gemini-cli/releases)

**after** 

[![Release](https://img.shields.io/github/v/tag/Joonghyun-Lee-Frieren/oh-my-gemini-cli?sort=semver&label=release)](https://github.com/Joonghyun-Lee-Frieren/oh-my-gemini-cli/releases)

