### PR TITLE
feat: add clarity scoring rubric and auto-init interview sessions

### DIFF
--- a/agents/interview.md
+++ b/agents/interview.md
@@ -10,7 +10,12 @@ You are a **Socratic Requirements Architect**. Your mission is to extract clear,
 ## Convergence
   - Limit questions to 3 nested sub-topics.
   - Summarize "Confirmed Facts" every 3 turns to maintain context efficiency.
-  - Calculate a `Clarity Score` (0-100) based on the user's responses.
+  - Calculate a `Clarity Score` (0-100) based on the user's responses:
+    - Core objective defined: +20
+    - Target audience/context clear: +20
+    - Technical constraints/stack identified: +20
+    - Edge cases/risks considered: +20
+    - Acceptance criteria defined: +20
 - **Termination Criteria**:
   - `low`: Stop when Clarity Score > 65.
   - `medium`: Stop when Clarity Score > 80.
@@ -26,7 +31,7 @@ You are a **Socratic Requirements Architect**. Your mission is to extract clear,
 ## Protocol
 1. **[Initialize]**: **CRITICAL**: Always check for `.omg/state/interviews/active.json` using `read_file`.
    - **If the active pointer exists**: Resolve and load `.omg/state/interviews/[slug]/context.json`. This is the ONLY source of truth. Ignore any conflicting internal memory or previous conversation turns.
-   - **If the file is missing**: **Request the user to start** a new interview session by running `/omg:intent low|medium|high [query]`.
+   - **If the file is missing**: **Auto-initialize** a new session folder, create `.omg/state/interviews/active.json` pointing to it, and seed the initial `.omg/state/interviews/[slug]/context.json` with the current user request.
 2. **[Interview]**: Engage in dialogue. Every question and update must build upon the state found in the active session JSON file.
 3. **[Persist]**: Update `.omg/state/interviews/[slug]/context.json` after every single turn. Ensure the JSON is valid and reflects the latest `clarity_score` and `facts`.
 4. **[Finalize]**: On meeting the depth threshold or `$intent-done`, generate the PRD and transition the workflow.

--- a/commands/omg/interview.toml
+++ b/commands/omg/interview.toml
@@ -8,7 +8,7 @@ $ARGUMENTS
 Protocol:
 1. Initialize or Resume:
    - **Check First**: Use `read_file` to verify the existence of `.omg/state/interviews/active.json`.
-   - **If the file is missing**: **Request the user to start** an active interview via `/omg:intent [depth]`.
+   - **If the file is missing**: **Auto-initialize** a new session folder, create `.omg/state/interviews/active.json` pointing to it, and seed the initial `.omg/state/interviews/[slug]/context.json` with the current user request.
    - **If resuming**: Resolve the active session folder from `.omg/state/interviews/active.json`, then surface the `ready_to_run_prompt` from `.omg/state/interviews/[slug]/context.json`.
 2. Socratic Dialogue:
    - Invoke the `interview` agent.
@@ -17,6 +17,12 @@ Protocol:
    - Ask ONE targeted Socratic question.
 3. Convergence & Scoring:
    - Update `clarity_score`, `facts`, and `questions_asked` in `.omg/state/interviews/[slug]/context.json`.
+   - Scoring Criteria (0-100):
+     - Core objective defined: +20
+     - Target audience/context clear: +20
+     - Tech stack/constraints identified: +20
+     - Edge cases considered: +20
+     - Acceptance criteria set: +20
    - Thresholds:
      - `low`: Score > 65
      - `medium`: Score > 80


### PR DESCRIPTION
Clarity Score description with a deterministic 5-criterion rubric (+20 each) in both the interview agent and command. Switch missing-session behavior from prompting the user to auto-initializing a new session folder and context.json.